### PR TITLE
Fix dtype error

### DIFF
--- a/maxspin/binning.py
+++ b/maxspin/binning.py
@@ -1,3 +1,4 @@
+
 from anndata import AnnData
 import numpy as np
 import squidpy as sq
@@ -42,6 +43,7 @@ def kdtree_bin_points(xy, leafsize: int, firstdim: int):
         clusters[group] = cluster
 
     return clusters
+
 
 
 def spatially_bin_adata(adata: AnnData, binsize: float, kdfirstdim: int=0):
@@ -104,3 +106,4 @@ def spatially_bin_adata(adata: AnnData, binsize: float, kdfirstdim: int=0):
     sq.gr.spatial_neighbors(binned_adata, coord_type="generic", delaunay=True)
 
     return binned_adata
+

--- a/maxspin/binning.py
+++ b/maxspin/binning.py
@@ -1,4 +1,3 @@
-
 from anndata import AnnData
 import numpy as np
 import squidpy as sq
@@ -17,24 +16,24 @@ def kdtree_bin_points(xy, leafsize: int, firstdim: int):
 
     groups = []
 
-    def kdbuild(xy, idxs, dim: int=0):
+    def kdbuild(xy, idxs, dim: int = 0):
         nodesize = xy.shape[0]
 
         if nodesize == leafsize:
             groups.append(idxs)
             return
 
-        perm = xy[:,dim].argsort()
+        perm = xy[:, dim].argsort()
 
-        xy = xy[perm,:]
+        xy = xy[perm, :]
         idxs = idxs[perm]
 
         mid = int(((nodesize / leafsize) // 2) * leafsize)
 
         dim = (dim + 1) % 2
 
-        kdbuild(xy[:mid,:], idxs[:mid], dim)
-        kdbuild(xy[mid:,:], idxs[mid:], dim)
+        kdbuild(xy[:mid, :], idxs[:mid], dim)
+        kdbuild(xy[mid:, :], idxs[mid:], dim)
 
     kdbuild(xy, np.arange(ncells), firstdim)
 
@@ -45,8 +44,7 @@ def kdtree_bin_points(xy, leafsize: int, firstdim: int):
     return clusters
 
 
-
-def spatially_bin_adata(adata: AnnData, binsize: float, kdfirstdim: int=0):
+def spatially_bin_adata(adata: AnnData, binsize: float, kdfirstdim: int = 0):
     """
     Spatially bin an AnnData.
     """
@@ -60,7 +58,7 @@ def spatially_bin_adata(adata: AnnData, binsize: float, kdfirstdim: int=0):
     mask = np.ones(ncells, dtype=bool)
     mask[rng.permutation(np.arange(ncells))[0:remainder]] = 0
 
-    adata = adata[mask,:]
+    adata = adata[mask, :]
     ncells, ngenes = adata.shape
 
     xy = np.asarray(adata.obsm["spatial"])
@@ -72,12 +70,12 @@ def spatially_bin_adata(adata: AnnData, binsize: float, kdfirstdim: int=0):
     # X = np.asarray(adata.X)
     X = adata.X
 
-    nclusters = np.max(clusters)+1
+    nclusters = np.max(clusters) + 1
     binned_X = np.zeros((nclusters, ngenes), dtype=X.dtype)
-    binned_xy = np.zeros((nclusters, 2), dtype=xy.dtype)
+    binned_xy = np.zeros((nclusters, 2), dtype="float64")
     for i in range(ncells):
-        binned_X[clusters[i],:] += X[i,:]
-        binned_xy[clusters[i],:] += xy[i,:]
+        binned_X[clusters[i], :] += X[i, :]
+        binned_xy[clusters[i], :] += xy[i, :]
     binned_xy /= binsize
 
     # make sure we didn't lose anything here
@@ -85,7 +83,8 @@ def spatially_bin_adata(adata: AnnData, binsize: float, kdfirstdim: int=0):
         np.sum(binned_X, dtype=np.float64),
         np.sum(X, dtype=np.float64),
         atol=1e-1,
-        rtol=1e-8)
+        rtol=1e-8,
+    )
 
     # bin standard deviations if they are present
     obsm = {"spatial": binned_xy}
@@ -93,17 +92,14 @@ def spatially_bin_adata(adata: AnnData, binsize: float, kdfirstdim: int=0):
         std = adata.obsm["std"]
         binned_std = np.zeros((nclusters, ngenes))
         for i in range(ncells):
-            binned_std[clusters[i],:] += np.square(std[i,:])
+            binned_std[clusters[i], :] += np.square(std[i, :])
         binned_std = np.sqrt(binned_std)
         obsm["std"] = binned_std
 
     binned_adata = AnnData(
-        X=binned_X,
-        var=adata.var,
-        obsm=obsm,
-        uns={"binsize": binsize})
+        X=binned_X, var=adata.var, obsm=obsm, uns={"binsize": binsize}
+    )
 
     sq.gr.spatial_neighbors(binned_adata, coord_type="generic", delaunay=True)
 
     return binned_adata
-


### PR DESCRIPTION
While running the example in the readme, the code fails with the following error

```
import squidpy as sq
from maxspin import spatial_information

adata = sq.datasets.visium('V1_Human_Brain_Section_1')

sq.gr.spatial_neighbors(adata, delaunay=True, coord_type="generic")

spatial_information(adata)
```

The error that the last line gives is the following 

```
nsamples: 1
ngenes: 36601

---------------------------------------------------------------------------
UFuncTypeError                            Traceback (most recent call last)
Cell In [16], line 1
----> 1 spatial_information(adata)

File ~/anaconda3/envs/squidpy_env/lib/python3.9/site-packages/maxspin/spatial_information.py:165, in spatial_information(adatas, nwalksteps, stepsize, lr, nepochs, binsizes, binweights, max_unimproved_count, seed, prior, prior_k, prior_theta, prior_a, estimate_scales, chunk_size, alpha_layer, beta_layer, receiver_signals, resample_frequency, nevalsamples, preload, quiet)
    162 cell_counts.append(1)
    163 objective_weights.append(1.0)
--> 165 binned_adatas = [spatially_bin_adata(adata, binsize) for binsize in binsizes]
    166 concatenated_adatas.extend(binned_adatas)
    167 cell_counts.extend(binsizes)

File ~/anaconda3/envs/squidpy_env/lib/python3.9/site-packages/maxspin/spatial_information.py:165, in <listcomp>(.0)
    162 cell_counts.append(1)
    163 objective_weights.append(1.0)
--> 165 binned_adatas = [spatially_bin_adata(adata, binsize) for binsize in binsizes]
    166 concatenated_adatas.extend(binned_adatas)
    167 cell_counts.extend(binsizes)

File ~/anaconda3/envs/squidpy_env/lib/python3.9/site-packages/maxspin/binning.py:81, in spatially_bin_adata(adata, binsize, kdfirstdim)
     79     binned_X[clusters[i],:] += X[i,:]
     80     binned_xy[clusters[i],:] += xy[i,:]
---> 81 binned_xy /= binsize
     83 # make sure we didn't lose anything here
     84 assert np.isclose(
     85     np.sum(binned_X, dtype=np.float64),
     86     np.sum(X, dtype=np.float64),
     87     atol=1e-1,
     88     rtol=1e-8)

UFuncTypeError: Cannot cast ufunc 'true_divide' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
```

The issue seems to be that in binning `adata.obsm["spatial"]` is an integer for 10x data. `binned_xy` is forced to be the same type as that and we're assigning a normalised value which is a float to this variable. Put in the minimal fix for that.